### PR TITLE
Add some Sphinx Directives that need to be ignored.

### DIFF
--- a/rstcheck.py
+++ b/rstcheck.py
@@ -172,7 +172,13 @@ class IgnoredDirective(docutils.parsers.rst.Directive):
         return []
 
 # Ignore Sphinx directives.
-docutils.parsers.rst.directives.register_directive('toctree', IgnoredDirective)
+# Use a tuple to store Sphinx driectives that need to be ignored
+ignored_directives = ('toctree', 'todo', 
+                      'versionadded', 'versionchanged', 
+                      'deprecated', 'seealso', 'centered', 
+                      'hlist', 'glossary', 'productionlist')
+for directive in ignored_directives:
+    docutils.parsers.rst.directives.register_directive(directive, IgnoredDirective)
 
 
 def bash_checker(code):


### PR DESCRIPTION
According to [issus#1](https://github.com/myint/rstcheck/issues/1), we need to ignore some Sphinx Directives because docutils doesn't support all the newest Sphinx tags. Thus, I add some other Sphinx Directives in addition to `toctree`. **More details please see rstcheck.py line 175**.

However, I think we need to fix module `docutils.parsers.rst.languages.en` if we want to fix this bug completely
