### PR TITLE
Ignore common Sphinx-specific roles.

### DIFF
--- a/examples/unknown.rst
+++ b/examples/unknown.rst
@@ -2,6 +2,8 @@
 Test
 ====
 
+File reeference: :file:`~/.bashrc`.
+
 .. code-block::
 
     foo

--- a/rstcheck.py
+++ b/rstcheck.py
@@ -187,6 +187,40 @@ for _directive in [
                                                        IgnoredDirective)
 
 
+def ignore_role(name, rawtext, text, lineno, inliner, options={},
+                content=[]):
+    """Stub for unknown roles."""
+    return ([], [])
+
+
+# Ignore Sphinx roles.
+for _role in [
+        'ref',
+        'doc',
+        'download',
+        'envvar',
+        'token',
+        'keyword',
+        'option',
+        'term',
+        'abbr',
+        'command',
+        'dfn',
+        'file',
+        'guilabel',
+        'kbd',
+        'mailheader',
+        'makevar',
+        'manpage',
+        'menuselection',
+        'mimetype',
+        'newsgroup',
+        'program',
+        'regexp',
+        'samp']:
+    docutils.parsers.rst.roles.register_local_role(_role, ignore_role)
+
+
 def bash_checker(code):
     """Return checker."""
     run = run_in_subprocess(code, '.bash', ['bash', '-n'])


### PR DESCRIPTION
This is related to a recent [issue](https://github.com/scrooloose/syntastic/issues/1195) reported for syntastic.  The attached patch makes checking Sphinx documents somewhat more useful, by ignoring (most of the) standard Sphnix roles.  The patched `rstcheck` still doesn't do a great job parsing the [Hitchhiker's Guide to Python](https://github.com/kennethreitz/python-guide), but it does make that task less of a pain.

Reference: [Sphinx markup](http://sphinx-doc.org/markup/inline.html).
