### PR TITLE
catch python code-block SyntaxWarnings and make them lint errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Links on the versions point to PyPI.
 
 [diff v6.0.0rc1...main](https://github.com/rstcheck/rstcheck/compare/v6.0.0rc1...main)
 
+### New features
+
+- Catch SyntaxWarnings in python code-blocks and handle them like SyntaxErrors ([#124](https://github.com/rstcheck/rstcheck/pull/124))
+
 ### Documentation
 
 - Update links to new repository home at rstcheck/rstcheck

--- a/src/rstcheck/checker.py
+++ b/src/rstcheck/checker.py
@@ -14,6 +14,7 @@ import subprocess  # noqa: S404
 import sys
 import tempfile
 import typing as t
+import warnings
 import xml.etree.ElementTree  # noqa: S405
 
 import docutils.core
@@ -534,7 +535,9 @@ class CodeBlockChecker:
         """
         logger.debug("Check python source.")
         try:
-            compile(source_code, "<string>", "exec")
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", SyntaxWarning)
+                compile(source_code, "<string>", "exec")
         except SyntaxError as exception:
             yield types.LintError(
                 source_origin=self.source_origin,

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -541,6 +541,44 @@ print(
         assert "'(' was never closed" in result[0]["message"]
 
     @staticmethod
+    @pytest.mark.skipif(sys.version_info[0:2] > (3, 7), reason="Requires python3.7 or lower")
+    def test_check_python_returns_no_error_on_syntax_warning_pre38() -> None:
+        """Test ``check_python`` returns no error on SyntaxWarning.
+
+        With python 3.8 a SyntaxWarning is logged for '"is" with literals'.
+
+        Context: https://github.com/rstcheck/rstcheck/issues/122
+        """
+        source = """
+if mystring is "ok":
+    ...
+"""
+        cb_checker = checker.CodeBlockChecker("<string>")
+
+        result = list(cb_checker.check_python(source))
+
+        assert not result
+
+    @staticmethod
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="Requires python3.8 or higher")
+    def test_check_python_returns_error_on_syntax_warning() -> None:
+        """Test ``check_python`` returns error on SyntaxWarning.
+
+        With python 3.8 a SyntaxWarning is logged for '"is" with literals'.
+
+        Context: https://github.com/rstcheck/rstcheck/issues/122
+        """
+        source = """
+if mystring is "ok":
+    ...
+"""
+        cb_checker = checker.CodeBlockChecker("<string>")
+
+        result = list(cb_checker.check_python(source))
+
+        assert '"is" with a literal' in result[0]["message"]
+
+    @staticmethod
     def test_check_json_returns_none_on_ok_code_block() -> None:
         """Test ``check_json`` returns ``None`` on ok code block."""
         source = """


### PR DESCRIPTION
In bpo-34850 python 3.8 added a SyntaxWarning on "is" with a literal.
SyntaxWarnings in general are now catched and handled like SyntaxErrors.

fixes: #122

<!-- markdownlint-disable MD033 -->
<!-- PLEASE READ !!!

    The checklist below is just a reminder about the most common mistakes.
    and should *not* deter you from submitting but rather *help* you improve your contribution.
    But please tick all the boxes appropriately.

-->

# Check List

Resolves: #<issue number here>

- [x] I added **tests** for the changed code.
- [x] I updated the **documentation** for the changed code.
- [x] I ran the **full** `tox` test suite locally, so the CI pipelines should be green.
- [x] I added the change to the History section on the README.

<!--
    Please add further information below that may help
    the maintainers understand what you intend to solve.
-->
