### PR TITLE
Improve config loading - add special NONE config path

### DIFF
--- a/src/rstcheck/_cli.py
+++ b/src/rstcheck/_cli.py
@@ -12,10 +12,12 @@ ValidReportLevels = _t.Literal["INFO", "WARNING", "ERROR", "SEVERE", "NONE"]
 
 HELP_CONFIG = """Config file to load. Can be a INI file or directory.
 If a directory is passed it will be searched for .rstcheck.cfg | setup.cfg.
+If 'NONE' is passed no config file is loaded at all.
 """
 if _extras.TOMLI_INSTALLED:  # pragma: no cover
     HELP_CONFIG = """Config file to load. Can be a INI or TOML file or directory.
 If a directory is passed it will be searched for .rstcheck.cfg | pyproject.toml | setup.cfg.
+If 'NONE' is passed no config file is loaded at all.
 """
 HELP_WARN_UNKNOWN_SETTINGS = """Log a WARNING for unknown settings in config files.
 Can be hidden via --log-level."""

--- a/src/rstcheck/config.py
+++ b/src/rstcheck/config.py
@@ -214,8 +214,14 @@ def _load_config_from_ini_file(
     :raises FileNotFoundError: If the file is not found
     :return: instance of :py:class:`RstcheckConfigFile` or :py:class:`None` on missing config
         section
+        or ``NONE`` is passed as the config path.
     """
     logger.debug(f"Try loading config from INI file: '{ini_file}'")
+
+    if ini_file.name == "NONE":
+        logger.info("Config path is set to 'NONE'. No config file is loaded.")
+        return None
+
     resolved_file = ini_file.resolve()
 
     if not resolved_file.is_file():
@@ -284,9 +290,14 @@ def _load_config_from_toml_file(
     :raises ValueError: If the file is not a TOML file
     :raises FileNotFoundError: If the file is not found
     :return: instance of :py:class:`RstcheckConfigFile` or :py:obj:`None` on missing config section
+        or ``NONE`` is passed as the config path.
     """
     _extras.install_guard("tomli")
     logger.debug(f"Try loading config from TOML file: '{toml_file}'.")
+
+    if toml_file.name == "NONE":
+        logger.info("Config path is set to 'NONE'. No config file is loaded.")
+        return None
 
     resolved_file = toml_file.resolve()
 
@@ -344,8 +355,14 @@ def load_config_file(
         defaults to :py:obj:`False`
     :raises FileNotFoundError: If the file is not found
     :return: instance of :py:class:`RstcheckConfigFile` or :py:obj:`None` on missing config section
+        or ``NONE`` is passed as the config path.
     """
     logger.debug("Try loading config file.")
+
+    if file_path.name == "NONE":
+        logger.info("Config path is set to 'NONE'. No config file is loaded.")
+        return None
+
     if file_path.suffix.casefold() == ".toml":
         return _load_config_from_toml_file(
             file_path,
@@ -378,8 +395,14 @@ def load_config_file_from_dir(
         defaults to :py:obj:`False`
     :return: instance of :py:class:`RstcheckConfigFile` or
         :py:obj:`None` if no file is found or no file has a rstcheck section
+        or ``NONE`` is passed as the config path.
     """
     logger.debug(f"Try loading config file from directory: '{dir_path}'.")
+
+    if dir_path.name == "NONE":
+        logger.info("Config path is set to 'NONE'. No config file is loaded.")
+        return None
+
     config = None
 
     for file_name in CONFIG_FILES:
@@ -423,8 +446,14 @@ def load_config_file_from_dir_tree(
         defaults to :py:obj:`False`
     :return: instance of :py:class:`RstcheckConfigFile` or
         :py:obj:`None` if no file is found or no file has a rstcheck section
+        or ``NONE`` is passed as the config path.
     """
     logger.debug(f"Try loading config file from directory tree: '{dir_path}'.")
+
+    if dir_path.name == "NONE":
+        logger.info("Config path is set to 'NONE'. No config file is loaded.")
+        return None
+
     config = None
 
     search_dir = dir_path.resolve()
@@ -476,10 +505,17 @@ def load_config_file_from_path(
         defaults to :py:obj:`False`
     :param warn_unknown_settings: If a warning should be logged for unknown settings in config file;
         defaults to :py:obj:`False`
+    :raises OSError: When the passed path is neither a file nor a directory.
     :return: instance of :py:class:`RstcheckConfigFile` or
         :py:obj:`None` if no file is found or no file has a rstcheck section
+        or ``NONE`` is passed as the config path.
     """
     logger.debug(f"Try loading config file from path: '{path}'.")
+
+    if path.name == "NONE":
+        logger.info("Config path is set to 'NONE'. No config file is loaded.")
+        return None
+
     resolved_path = path.resolve()
 
     if resolved_path.is_file():
@@ -502,8 +538,7 @@ def load_config_file_from_path(
             warn_unknown_settings=warn_unknown_settings,
         )
 
-    logger.warning("Passed path is neither a file nor a directory: '{path}'.")
-    return None
+    raise OSError(f"The passed path is neither a file nor a directory: '{path}'.")
 
 
 def merge_configs(

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -319,7 +319,7 @@ class TestWithConfigFile:
     ) -> None:
         """Test bad file ``bad.rst`` without config file is not ok."""
         test_file = EXAMPLES_DIR / "with_configuration" / "bad.rst"
-        config_file = "no-config-file"
+        config_file = pathlib.Path("NONE")
 
         result = cli_runner.invoke(cli_app, [str(test_file), "--config", str(config_file)])
 
@@ -337,7 +337,7 @@ class TestWithConfigFile:
         ``(ERROR/3) (cpp) warning: no newline at end of file [-Wnewline-eof]``
         """
         test_file = EXAMPLES_DIR / "with_configuration" / "bad.rst"
-        config_file = "no-config-file"
+        config_file = pathlib.Path("NONE")
 
         result = cli_runner.invoke(cli_app, [str(test_file), "--config", str(config_file)])
 
@@ -350,7 +350,7 @@ class TestWithConfigFile:
     ) -> None:
         """Test bad file ``bad_rst.rst`` without config file not ok."""
         test_file = EXAMPLES_DIR / "with_configuration" / "bad_rst.rst"
-        config_file = "no-config-file"
+        config_file = pathlib.Path("NONE")
 
         result = cli_runner.invoke(cli_app, [str(test_file), "--config", str(config_file)])
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -388,6 +388,15 @@ class TestIniFileLoader:
     """Test ``load_config_from_ini_file``."""
 
     @staticmethod
+    def test_no_config_on_none() -> None:
+        """Test no config is loaded if NONE is set."""
+        conf_file = pathlib.Path("NONE")
+
+        result = config._load_config_from_ini_file(conf_file)  # pylint: disable=protected-access
+
+        assert result is None
+
+    @staticmethod
     def test_missing_file_errors(tmp_path: pathlib.Path) -> None:
         """Test ``FileNotFoundError`` is raised on missing file."""
         conf_file = tmp_path / "config.ini"
@@ -630,6 +639,15 @@ report_level=INFO
 @pytest.mark.skipif(not _extras.TOMLI_INSTALLED, reason="Depends on toml extra.")
 class TestTomlFileLoader:
     """Test ``load_config_from_toml_file``."""
+
+    @staticmethod
+    def test_no_config_on_none() -> None:
+        """Test no config is loaded if NONE is set."""
+        conf_file = pathlib.Path("NONE")
+
+        result = config._load_config_from_toml_file(conf_file)  # pylint: disable=protected-access
+
+        assert result is None
 
     @staticmethod
     def test_wrong_file_suffix_errors(tmp_path: pathlib.Path) -> None:
@@ -926,6 +944,15 @@ class TestConfigFileLoader:
     """Test ``load_config_file``."""
 
     @staticmethod
+    def test_no_config_on_none() -> None:
+        """Test no config is loaded if NONE is set."""
+        conf_file = pathlib.Path("NONE")
+
+        result = config.load_config_file(conf_file)
+
+        assert result is None
+
+    @staticmethod
     @pytest.mark.parametrize("ini_file", [".rstcheck.cfg", "setup.cfg", "config.ini", "config.cfg"])
     def test_ini_files(tmp_path: pathlib.Path, ini_file: str) -> None:
         """Test with INI files."""
@@ -959,6 +986,15 @@ class TestConfigFileLoader:
 
 class TestConfigDirLoader:
     """Test ``load_config_file_from_dir``."""
+
+    @staticmethod
+    def test_no_config_on_none() -> None:
+        """Test no config is loaded if NONE is set."""
+        conf_file = pathlib.Path("NONE")
+
+        result = config.load_config_file_from_dir(conf_file)
+
+        assert result is None
 
     @staticmethod
     @pytest.mark.parametrize("ini_file", [".rstcheck.cfg", "setup.cfg"])
@@ -1137,6 +1173,15 @@ class TestConfigDirTreeLoader:
     """Test ``load_config_file_from_dir_tree``."""
 
     @staticmethod
+    def test_no_config_on_none() -> None:
+        """Test no config is loaded if NONE is set."""
+        conf_file = pathlib.Path("NONE")
+
+        result = config.load_config_file_from_dir_tree(conf_file)
+
+        assert result is None
+
+    @staticmethod
     def test_parent_searching(tmp_path: pathlib.Path) -> None:
         """Test option to search up the dir tree."""
         nested_dir = tmp_path / "nested"
@@ -1191,9 +1236,19 @@ class TestConfigPathLoader:
     """Test ``load_config_file_from_path``."""
 
     @staticmethod
-    def test_with_nonexisting_path() -> None:
-        """Test with INI file."""
+    def test_raises_on_nonexisting_path() -> None:
+        """Test raises OSError on path that is not a file or directory."""
         conf_file = pathlib.Path("does-not-exist-cfg")
+
+        with pytest.raises(
+            OSError, match=f"The passed path is neither a file nor a directory: '{conf_file}'."
+        ):
+            config.load_config_file_from_path(conf_file)
+
+    @staticmethod
+    def test_no_config_on_none() -> None:
+        """Test no config is loaded if NONE is set."""
+        conf_file = pathlib.Path("NONE")
 
         result = config.load_config_file_from_path(conf_file)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD033 -->
<!-- PLEASE READ !!!

    The checklist below is just a reminder about the most common mistakes.
    and should *not* deter you from submitting but rather *help* you improve your contribution.
    But please tick all the boxes appropriately.

-->

# Check List

Resolves: #<issue number here>

- [x] I added **tests** for the changed code.
- [x] I updated the **documentation** for the changed code.
- [x] I ran the **full** `tox` test suite locally, so the CI pipelines should be green.
- [x] I added the change to the History section on the README.

<!--
    Please add further information below that may help
    the maintainers understand what you intend to solve.
-->

Add `NONE` as a special config file path, to disable config file loading.

`rstcheck.config.load_config_file_from_path` now raises an OSError if the given path is neither a file nor a directory.