### PR TITLE
Update tests after rstcheck-core C++ change.

### DIFF
--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -273,7 +273,6 @@ class TestWithoutConfigFile:
     @pytest.mark.xfail(
         sys.platform == "win32", reason="Unknown Windows specific wrong result", strict=True
     )
-    @pytest.mark.skipif(sys.platform == "darwin", reason="MacOS specific variant exists")
     def test_error_without_config_file(
         cli_app: typer.Typer, cli_runner: typer.testing.CliRunner
     ) -> None:
@@ -284,23 +283,6 @@ class TestWithoutConfigFile:
 
         assert result.exit_code != 0
         assert len(ERROR_CODE_REGEX.findall(result.stdout)) == 6
-
-    @staticmethod
-    @pytest.mark.skipif(sys.platform != "darwin", reason="MacOS specific error count")
-    def test_error_without_config_file_macos(
-        cli_app: typer.Typer, cli_runner: typer.testing.CliRunner
-    ) -> None:
-        """Test bad example without set config file and implicit config file shows errors.
-
-        On MacOS the cpp code block generates an additional error compared to linux:
-        ``(ERROR/3) (cpp) warning: no newline at end of file [-Wnewline-eof]``
-        """
-        test_file = EXAMPLES_DIR / "without_configuration" / "bad.rst"
-
-        result = cli_runner.invoke(cli_app, str(test_file))
-
-        assert result.exit_code != 0
-        assert len(ERROR_CODE_REGEX.findall(result.stdout)) == 7
 
     @staticmethod
     def test_no_error_with_set_ini_config_file(
@@ -347,7 +329,6 @@ class TestWithConfigFile:
     """Test with config file in dir tree."""
 
     @staticmethod
-    @pytest.mark.skipif(sys.platform == "darwin", reason="MacOS specific variant exists")
     def test_file_1_is_bad_without_config(
         cli_app: typer.Typer, cli_runner: typer.testing.CliRunner
     ) -> None:
@@ -359,24 +340,6 @@ class TestWithConfigFile:
 
         assert result.exit_code != 0
         assert len(ERROR_CODE_REGEX.findall(result.stdout)) == 6
-
-    @staticmethod
-    @pytest.mark.skipif(sys.platform != "darwin", reason="MacOS specific error count")
-    def test_file_1_is_bad_without_config_macos(
-        cli_app: typer.Typer, cli_runner: typer.testing.CliRunner
-    ) -> None:
-        """Test bad file ``bad.rst`` without config file is not ok.
-
-        On MacOS the cpp code block generates an additional error compared to linux:
-        ``(ERROR/3) (cpp) warning: no newline at end of file [-Wnewline-eof]``
-        """
-        test_file = EXAMPLES_DIR / "with_configuration" / "bad.rst"
-        config_file = pathlib.Path("NONE")
-
-        result = cli_runner.invoke(cli_app, [str(test_file), "--config", str(config_file)])
-
-        assert result.exit_code != 0
-        assert len(ERROR_CODE_REGEX.findall(result.stdout)) == 7
 
     @staticmethod
     def test_file_2_is_bad_without_config(


### PR DESCRIPTION
In rstcheck-core, we no longer return file does not end in a newline errors when checking C++ code blocks.

<!-- markdownlint-disable MD033 -->
<!-- PLEASE READ !!!

    The checklist below is just a reminder about the most common mistakes.
    and should *not* deter you from submitting but rather *help* you improve your contribution.
    But please tick all the boxes appropriately.

-->

# Check List

This is a follow up to https://github.com/rstcheck/rstcheck-core/pull/45 and can be merged when rstcheck-core is released. For tests, at least, the version constraint should be updated to allow that release (not done yet).

Should I update the CHANGELOG even though this is an internal CI change right now?

- [ ] I added **tests** for the changed code.
- [ ] I updated the **documentation** for the changed code.
- [ ] I ran the **full** `tox` test suite locally, so the CI pipelines should be green.
- [ ] I added the change to the CHANGELOG.md file.

<!--
    Please add further information below that may help
    the maintainers understand what you intend to solve.
-->
