### PR TITLE
Add entry point to enable execution via `python -m rstcheck`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ NOTE: please use them in this order.
 ### Miscellaneous
 
 - Remove unused pre python 3.8 compatibility code ([#195](https://github.com/rstcheck/rstcheck/pull/195))
+- Added `__main__.py` to enable command-line execution via python -m rstcheck
 
 ## [6.2.0 (2023-09-09)](https://github.com/rstcheck/rstcheck/releases/v6.2.0)
 

--- a/src/rstcheck/__main__.py
+++ b/src/rstcheck/__main__.py
@@ -1,0 +1,4 @@
+from ._cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/rstcheck/__main__.py
+++ b/src/rstcheck/__main__.py
@@ -1,3 +1,10 @@
+"""Executes CLI application's `main` function.
+
+This module acts as the entry point for the application. When executed as the
+main script, it calls the `main` function from the ._cli submodule to start the
+application.
+"""
+
 from __future__ import annotations
 
 from ._cli import main

--- a/src/rstcheck/__main__.py
+++ b/src/rstcheck/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ._cli import main
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- markdownlint-disable MD033 -->
<!-- PLEASE READ !!!

    The checklist below is just a reminder about the most common mistakes.
    and should *not* deter you from submitting but rather *help* you improve your contribution.
    But please tick all the boxes appropriately.

-->

# Check List

Resolves: #<issue number here>

- [ ] I added **tests** for the changed code.
- [x] I updated the **documentation** for the changed code.
- [x] I ran the **full** `tox` test suite locally, so the CI pipelines should be green.
- [x] I added the change to the CHANGELOG.md file.

<!--
    Please add further information below that may help
    the maintainers understand what you intend to solve.
-->
This pull request introduces a new file `__main__.py` in the `src/rstcheck` directory, creating an entry point for the `rstcheck` command line interface. This update allows for execution using `python -m rstcheck`. This change addresses an issue observed in dependent packages, where the lack of a __main__.py file broke execution attempts via python -m, as exemplified by the issue in [the Visual Studio Code extension for reStructuredText](https://marketplace.visualstudio.com/items?itemName=lextudio.restructuredtext).

