### PR TITLE
Fix typo in CLI docs

### DIFF
--- a/src/rstcheck/_cli.py
+++ b/src/rstcheck/_cli.py
@@ -154,7 +154,7 @@ cli.__doc__ = f"""CLI of rstcheck.
 
 Enabled features: {enabled_features}
 
-Pass one ore more rst FILES to check.
+Pass one or more RST FILES to check.
 Can be files or directories if --recursive is passed too.
 Pass "-" if you want to read from stdin.
 """


### PR DESCRIPTION
Spotted on the webpage rendering,
https://rstcheck.readthedocs.io/en/latest/usage/cli/

<!-- markdownlint-disable MD033 -->
<!-- PLEASE READ !!!

    The checklist below is just a reminder about the most common mistakes.
    and should *not* deter you from submitting but rather *help* you improve your contribution.
    But please tick all the boxes appropriately.

-->

# Check List

Resolves: #<issue number here>

- [ ] I added **tests** for the changed code.
- [x] I updated the **documentation** for the changed code.
- [ ] I ran the **full** `tox` test suite locally, so the CI pipelines should be green.
- [ ] I added the change to the CHANGELOG.md file.

<!--
    Please add further information below that may help
    the maintainers understand what you intend to solve.
-->
