### PR TITLE
Remove dpendencies for Python < 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,6 @@ dynamic = ["version"]
 
 dependencies = [
   "rstcheck-core >=1.1",
-  "importlib-metadata >=1.6; python_version<='3.8'",
-  "typing-extensions >=3.7.4; python_version<='3.8'",
   "typer[all]  >=0.4.1",
 ]
 


### PR DESCRIPTION
https://github.com/rstcheck/rstcheck/blob/main/pyproject.toml#L7 says `>=3.8`. `importlib-metadata` and `typing-extensions` had a constraint for `python_version<='3.8'`.

# Check List

Resolves: #<issue number here>

- [ ] I added **tests** for the changed code.
- [ ] I updated the **documentation** for the changed code.
- [ ] I ran the **full** `tox` test suite locally, so the CI pipelines should be green.
- [ ] I added the change to the CHANGELOG.md file.

<!--
    Please add further information below that may help
    the maintainers understand what you intend to solve.
-->
