### PR TITLE
bump min version of typer and use the new dependency group name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version"]
 
 dependencies = [
   "rstcheck-core >=1.1",
-  "typer[all]  >=0.4.1",
+  "typer[standard]  >=0.12.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
- changed 'all' to 'standard'
- bump min version from 0.12.0 beacuse of the rename

fixes: #223
