### PR TITLE
test: harden path assertions for Windows

### DIFF
--- a/tests/test_windows_paths.py
+++ b/tests/test_windows_paths.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
+
 
 def test_path_resolve_works_on_windows(tmp_path: Path):
     p = tmp_path / "a" / "b.rst"

--- a/tests/test_windows_paths.py
+++ b/tests/test_windows_paths.py
@@ -1,0 +1,10 @@
+import os
+from pathlib import Path
+
+def test_path_resolve_works_on_windows(tmp_path: Path):
+    p = tmp_path / "a" / "b.rst"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("title\n=====\n", encoding="utf-8")
+    assert p.resolve().exists()
+    # avoid assumptions that break on Windows drive letters
+    assert os.path.isabs(str(p.resolve()))


### PR DESCRIPTION
Related to #107

Avoids path assumptions that fail on Windows drive letters.
